### PR TITLE
Fix missing definitions, adding cc.TextureCache class

### DIFF
--- a/cocos2d/core/boot.d.ts
+++ b/cocos2d/core/boot.d.ts
@@ -1066,6 +1066,11 @@ declare namespace cc {
     export const winSize:Size;
 
     // Parsers
+    /**
+     * @type {cc.SAXParser}
+     * @name cc.plistParser
+     * A SAX Parser
+     */
     export const saxParser:SAXParser;
 
     /**
@@ -1126,14 +1131,34 @@ declare namespace cc {
         export function setFrameRate(frameRate:number):void;
 
         /**
+         * Check whether the game is paused.
+         */
+        export function isPaused(): boolean;
+
+        /**
+         * Pause the game. 
+         */
+        export function pause(): void;
+
+        /**
          * Restart game.
          */
         export function restart():void;
 
         /**
+        * Resume the game from pause.
+        */
+        export function resume(): void;
+
+        /**
          * Run game.
          */
         export function run(id?:number):void;
+
+        /**
+         * End game, it will close the game window.
+         */
+        export function end(): void;
 
         /**
          * Prepare game.

--- a/cocos2d/core/core.d.ts
+++ b/cocos2d/core/core.d.ts
@@ -154,6 +154,19 @@ declare namespace cc {
      */
     export function GLToClipTransform(xform: AffineTransform): void;
 
+
+    /**
+     * OpenGL projection protocol
+     * @class
+     * @extends cc.Class
+     */
+    export interface DirectorDelegate {
+        /**
+         * Called by CCDirector when the projection is updated, and "custom" projection is used
+         */
+        updateProjection(): void;
+    }
+    
     // Class Definitions
     /**
      * <p>

--- a/cocos2d/core/platform.d.ts
+++ b/cocos2d/core/platform.d.ts
@@ -1640,6 +1640,21 @@ declare namespace cc {
      * @extends cc.Class
      */
     export class ContainerStrategy extends Class {
+
+        /**
+         * Strategy that scale proportionally the container's size to frame's size
+         */
+        static PROPORTION_TO_FRAME: ContainerStrategy;
+
+        /**
+         * Strategy that makes the container's size equals to the frame's size
+         */
+        static EQUAL_TO_FRAME: ContainerStrategy;
+
+        /**
+         * Strategy that keeps the original container's size
+         */
+        static ORIGINAL_CONTAINER: ContainerStrategy;
         /**
          * Manipulation before appling the strategy
          * @param {cc.view} view The target view
@@ -1668,6 +1683,32 @@ declare namespace cc {
      * @extends cc.Class
      */
     export class ContentStrategy extends Class {
+
+        /**
+         * Strategy to scale the content's size to container's size, non proportional
+         */
+        static EXACT_FIT: ContentStrategy;
+
+        /**
+         * Strategy to scale the content's size proportionally to maximum size and keeps the whole content area to be visible
+         */
+        static SHOW_ALL: ContentStrategy;
+
+        /**
+         * Strategy to scale the content's size proportionally to fill the whole container area
+         */
+        static NO_BORDER: ContentStrategy;
+
+        /**
+         * Strategy to scale the content's height to container's height and proportionally scale its width
+         */
+        static FIXED_HEIGHT: ContentStrategy;
+
+        /**
+         * Strategy to scale the content's width to container's width and proportionally scale its height
+         */
+        static FIXED_WIDTH: ContentStrategy;
+
         /**
          * Manipulation before applying the strategy
          * @param {cc.view} view The target view

--- a/cocos2d/core/textureCache.d.ts
+++ b/cocos2d/core/textureCache.d.ts
@@ -1,0 +1,74 @@
+/// <reference path="../cocos2d-lib.d.ts" />
+
+
+declare namespace cc {
+
+     /**
+     * cc.textureCache is a singleton object, it's the global cache for cc.Texture2D
+     */
+    export const textureCache: TextureCache;
+
+    /**
+     * cc.textureCache is a singleton object, it's the global cache for cc.Texture2D
+     * @class
+     * @name cc.textureCache
+     */
+    export class TextureCache extends Class {
+        constructor();
+        init(): boolean;
+
+        /**
+         * Cache the image data
+         * @param path 
+         * @param texture 
+         */
+        cacheImage(path: string, texture: (Image | HTMLImageElement | HTMLCanvasElement)): void;
+
+        /** Returns "<TextureCache | Number of textures = " + this._textures.length + ">"
+         * @return string
+         */
+        description(): string;
+        
+        /**
+         * Output to cc.log the current contents of this TextureCache
+         * This will attempt to calculate the size of each texture, and the total texture memory in use.
+         */
+        dumpCachedTextureInfo(): void;
+
+        /**
+         * @param texture 
+         * @example 
+         * //var key = cc.textureCache.getKeyByTexture(texture);
+         */
+        getKeyByTexture(texture: Image): (String | null);
+
+        /**
+         * Returns an already created texture. Returns null if the texture doesn't exist.
+         * @param textureKeyName
+         */
+        getTextureForKey(textureKeyName: string): (Texture2D | null);
+
+        /**
+         * Purges the dictionary of loaded textures.
+         * Call this method if you receive the "Memory Warning"
+         * In the short term: it will free some resources preventing your app from being killed
+         * In the medium term: it will allocate more resources
+         * In the long term: it will be the same
+         */
+        removeAllTextures();
+
+        /**
+         * Deletes a texture from the cache given a texture
+         * @param texture 
+         */
+        removeTexture(texture: Image);
+
+        /**
+         * Deletes a texture from the cache given a its key name
+         * @param textureKeyName 
+         * @example
+         * `cc.textureCache.removeTexture("hello.png");`
+         */
+        removeTextureForKey(textureKeyName: string);
+    }
+}

--- a/cocos2d/tilemap/xml-parser.d.ts
+++ b/cocos2d/tilemap/xml-parser.d.ts
@@ -184,8 +184,23 @@ declare namespace cc {
     rectForGID(gid: number): Rect
   }
 
+  /**
+   * A SAX Parser
+   * @class
+   * @name cc.saxParser
+   * @extends cc.Class
+   */
   class SAXParser {}
   
+  /**
+    *
+    * cc.plistParser is a singleton object for parsing plist files
+    * @class
+    * @name cc.plistParser
+    * @extends cc.SAXParser
+    */
+  class PlistParser extends SAXParser { }
+
   /**
    * <p>cc.TMXMapInfo contains the information about the map like: <br/>
    *- Map orientation (hexagonal, isometric or orthogonal)<br/>


### PR DESCRIPTION
I made some changes that I thought other's might find useful, in particular the cc.TextureCache class. 

* Fixes missing PlistParser class and DirectorDelegate definitions. 
* Adding ContentStrategy & ContainerStrategy aliases.
* Adding missing cc.game functions. 
* Adding TextureCache class